### PR TITLE
fixed Column 'journalized_id' cannot be null; fixed journal duplications (foreach in foreach)

### DIFF
--- a/migrator.php
+++ b/migrator.php
@@ -52,7 +52,6 @@ class migrator
             3 => 3,
             4 => 4,
     );
-
     private $projectsMapping = array();
     private $categoriesMapping = array();
     private $versionsMapping = array();
@@ -588,9 +587,7 @@ class migrator
             $idIssueNew = $this->dbNew->insert('issues', $issueOld);
             $this->issuesMapping[$idIssueOld] = $idIssueNew;
 
-            foreach ($issuesOld as $issueOld) {
-                $this->migrateJournals($issueOld['id']);
-            }
+            $this->migrateJournals($idIssueOld);
         }
     }
 
@@ -677,4 +674,5 @@ class migrator
 
 $migrator = new migrator('localhost', 'redmine', 'root', '',
                             'localhost', 'redmine_new',   'root', '');
+
 $migrator->migrateProject(86);

--- a/migrator.php
+++ b/migrator.php
@@ -52,6 +52,7 @@ class migrator
             3 => 3,
             4 => 4,
     );
+
     private $projectsMapping = array();
     private $categoriesMapping = array();
     private $versionsMapping = array();


### PR DESCRIPTION
Hi @PowerKiKi,

I tried today this tool to move data from a Redmine instance to another one and I found 2 issues:
1) Column 'journalized_id' cannot be null

```
Query - La requete a echouee INSERT INTO `journals` (…) VALUES (…)  
Error n°1048: Column 'journalized_id' cannot be null
```

because the $issueOld['id'] that was send to migrateJournals is null (see some lines above unset ($issueOld['id']) 

2) There is a foreach in foreach that inserts the journal and journal details for all issues for each issue.

This pull request solves both issues.

If you are interested you can review it and merge it.
